### PR TITLE
Normalization of TabLine, TabLineFill, TabLineSel colors

### DIFF
--- a/colors/nefertiti.vim
+++ b/colors/nefertiti.vim
@@ -93,7 +93,7 @@ if !exists("g:did_nefertiti_code_setup")
         """ Cursor Line/Column {{{4
         hi CursorColumn     guibg=#000000
         hi CursorLine       guibg=#000000
-        hi CursorLineNr     guifg=#ffee99 guibg=bg gui=none
+        hi CursorLineNr     guifg=#ffee99   guibg=bg        gui=none
         hi ColorColumn      guibg=#202020
         """ }}}4
         """ Structural {{{4
@@ -105,9 +105,9 @@ if !exists("g:did_nefertiti_code_setup")
         hi FoldColumn       guifg=#68838b   guibg=#4B4B4B   gui=bold
         """ }}}4
         """ Tabs {{{4
-        hi TabLine          guifg=fg        guibg=#d3d3d3   gui=underline
-        hi TabLineFill      guifg=fg        guibg=bg        gui=reverse
-        hi TabLineSel       guifg=fg        guibg=bg        gui=bold
+        hi TabLine          guifg=#ddd6c0   guibg=#9d9080   gui=NONE
+        hi TabLineFill      guifg=#9d9080   guibg=#ddd6c0   gui=reverse
+        hi TabLineSel       guibg=#2c2824   guifg=#ddd6c0   gui=bold
         """ }}}4
         """ Search {{{4
         hi IncSearch        guifg=#000000   guibg=#ff8800   gui=BOLD


### PR DESCRIPTION
I use MacVim with `set guioptions-=e` and inactive tabs are almost unreadable, so i decided to give them a fixed color appearance using the default colors you've used for text and statusline. 
#### Original:

![screen shot 2014-07-01 at 15 16 48](https://cloud.githubusercontent.com/assets/1120284/3443376/0848fe02-0122-11e4-9394-b55a96fc10b0.png)
#### Modified:

![screen shot 2014-07-01 at 15 16 25](https://cloud.githubusercontent.com/assets/1120284/3443377/09c2e3a6-0122-11e4-83d7-ba8bcd4e22e0.png)

Tell me if you find this somewhat useful.
