### PR TITLE
Fix links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nefertiti
 
 
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_1.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_1.png" width=350 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_1.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_1.png" width=350 /></a>
 
 A warm dark-background color scheme for Vim (previously known as "MochaLatte"),
 featuring dynamic control of brightness-levels as needed.
@@ -66,9 +66,9 @@ also need something like the following in your "`~/.vimrc`":
 
 ## Samples
 
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_1.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_1.png" width=200 /></a>
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_2.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_2.png" width=200 /></a>
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_3.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_3.png" width=200 /></a>
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_4.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_4.png" width=200 /></a>
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_5.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_5.png" width=200 /></a>
-<a href="http://jeetworks.org/wp-content/uploads/vim-nefertiti_6.png" target="_blank"><img src="http://jeetworks.org/wp-content/uploads/vim-nefertiti_6.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_1.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_1.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_2.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_2.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_3.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_3.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_4.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_4.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_5.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_5.png" width=200 /></a>
+<a href="http://jeetblogs.org/media/images/vim-nefertiti_6.png" target="_blank"><img src="http://jeetblogs.org/media/images/vim-nefertiti_6.png" width=200 /></a>

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ and/or replace them with others of your own preference.
     $ cd ~/.vim/bundle
     $ git clone git://github.com/jeetsukumaran/vim-nefertiti
 
-### [Vundle](https://github.com/gmarik/vundle.git)
+### [Vundle](https://github.com/VundleVim/Vundle.vim)
 
     :BundleInstall jeetsukumaran/vim-nefertiti
 
@@ -57,7 +57,7 @@ Three commands are provided to control the brightness levels: "`:NefertitiBright
 By default, "`META-2`" ("`ALT-2`" on some keyboards) increases the brightness of the text while "`META-1`" ("`ALT-1`" on some keyboards) decreases the brightness of text. These key-mappings can be suppressed and or customized: see [the help](https://github.com/jeetsukumaran/vim-nefertiti/blob/master/doc/nefertiti.vim) for more details.
 
 Note that for the default (or any other "`META`" or "`ALT`") key mappings to
-work, if you are using [MacVim](https://code.google.com/p/macvim/), you will
+work, if you are using [MacVim](https://github.com/macvim-dev/macvim), you will
 also need something like the following in your "`~/.vimrc`":
 
     if has("gui_macvim")

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ To set the color scheme permanently, add the following to your "`~/.vimrc`":
         colorscheme nefertiti
     endif
 
-Three commands are provided to control the brightness levels: "`:NefertitiBrighten`", "`:NefertitiDarken`", and "`NefertitiReset`"; see [the help](https://github.com/jeetsukumaran/vim-nefertiti/blob/master/doc/nefertiti.txt) for more details.
+Three commands are provided to control the brightness levels: "`:NefertitiBrighten`", "`:NefertitiDarken`", and "`NefertitiReset`"; see [the help](https://github.com/jeetsukumaran/vim-nefertiti/blob/master/doc/nefertiti.vim) for more details.
 
-By default, "`META-2`" ("`ALT-2`" on some keyboards) increases the brightness of the text while "`META-1`" ("`ALT-1`" on some keyboards) decreases the brightness of text. These key-mappings can be suppressed and or customized: see [the help](https://github.com/jeetsukumaran/vim-nefertiti/blob/master/doc/nefertiti.txt) for more details.
+By default, "`META-2`" ("`ALT-2`" on some keyboards) increases the brightness of the text while "`META-1`" ("`ALT-1`" on some keyboards) decreases the brightness of text. These key-mappings can be suppressed and or customized: see [the help](https://github.com/jeetsukumaran/vim-nefertiti/blob/master/doc/nefertiti.vim) for more details.
 
 Note that for the default (or any other "`META`" or "`ALT`") key mappings to
 work, if you are using [MacVim](https://code.google.com/p/macvim/), you will


### PR DESCRIPTION
Hi, I really like this colorschme, thank you!

The screenshots in the README is currently not found, probably because you moved your blog. The first commit fixes these links to the current location of your article.

The link to the doc, as I happened to notice, is also 404 because of the extension (`.txt` vs `.vim`). So the second commit fixes these links --- You might want to rename the file instead.

The third commit is rather trivial: it updates links for project pages for Vundle and MacVim that have been changed (but are redirected anyway).